### PR TITLE
Remove deprecated method implementation

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -17,7 +17,7 @@
   <vendor>JetBrains</vendor>
   <category>VCS Integration</category>
   <depends>com.intellij.modules.vcs</depends>
-  <idea-version since-build="182.2258"></idea-version>
+  <idea-version since-build="192.4205"></idea-version>
 
   <project-components>
     <component>

--- a/src/net/sourceforge/transparent/History/CCaseHistoryProvider.java
+++ b/src/net/sourceforge/transparent/History/CCaseHistoryProvider.java
@@ -216,10 +216,6 @@ public class CCaseHistoryProvider implements VcsHistoryProvider, VcsCacheableHis
     return null;
   }
 
-  public Boolean getAddinionallyCachedData(CCaseHistorySession session) {
-    return null;
-  }
-
   public CCaseHistorySession createFromCachedData(@Nullable Boolean aBoolean,
                                                   @NotNull List<VcsFileRevision> revisions,
                                                   @NotNull FilePath filePath,


### PR DESCRIPTION
This method is deprecated since 192.4205 build, and replacement method has default implementation.